### PR TITLE
Update Dependabot configuration to check for npm updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "github-actions" # Check for updates to GitHub Actions every week
     directory: "/"
     schedule:


### PR DESCRIPTION
npmのマルウェアが入ったバージョンを踏まないように、dependabotの設定にcool downを設定。

合わせてアップデートの頻度を週1に変更。